### PR TITLE
Calculate 'exp' and 'iat' upon the same timestamp

### DIFF
--- a/lib/solidus_jwt/concerns/encodeable.rb
+++ b/lib/solidus_jwt/concerns/encodeable.rb
@@ -11,9 +11,10 @@ module SolidusJwt
     #
     def encode(payload:, expires_in: nil)
       # @see https://github.com/jwt/ruby-jwt#support-for-reserved-claim-names
+      current_time = Time.current
       extras = {}
-      extras['exp'] = Time.current.to_i + expires_in if expires_in.present?
-      extras['iat'] = Time.current
+      extras['exp'] = current_time.to_i + expires_in if expires_in.present?
+      extras['iat'] = current_time
 
       payload = extras.merge(payload).as_json
       JWT.encode(payload, SolidusJwt::Config.jwt_secret,


### PR DESCRIPTION
Using different `Time.current` calls could lead to slightly mismatches between `'exp'` and `'iat'` values